### PR TITLE
Use quicklisp/local-projects to simplify loading our system.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ WORKDIR /opt/representer
 env HOME /opt/representer
 
 # Pull down the latest Quicklisp
-ADD https://beta.quicklisp.org/quicklisp.lisp src/
+ADD https://beta.quicklisp.org/quicklisp.lisp quicklisp/
 
 # install quicklisp
-COPY src/ src/
-RUN sbcl --script ./src/install-quicklisp.lisp
+COPY src/install-quicklisp.lisp .
+RUN sbcl --script install-quicklisp.lisp
+COPY src quicklisp/local-projects
 
 # build the application
 COPY src/ src/

--- a/src/build.lisp
+++ b/src/build.lisp
@@ -1,4 +1,3 @@
-(load "src/setup-env")
-(let ((system "representer"))
-  (ql:quickload system)
-  (asdf:compile-system system))
+(load "quicklisp/setup")
+(ql:quickload "representer")
+(asdf:compile-system "representer")

--- a/src/generate.lisp
+++ b/src/generate.lisp
@@ -1,4 +1,4 @@
-(load "./src/setup-env")
-(asdf:load-system "representer")
+(load "quicklisp/setup")
+(ql:quickload "representer")
 
 (apply #'representer/main:main (uiop:command-line-arguments))

--- a/src/install-quicklisp.lisp
+++ b/src/install-quicklisp.lisp
@@ -1,2 +1,2 @@
-(load "./src/quicklisp.lisp")
+(load "quicklisp/quicklisp.lisp")
 (quicklisp-quickstart:install)

--- a/src/setup-env.lisp
+++ b/src/setup-env.lisp
@@ -1,2 +1,0 @@
-(load "quicklisp/setup")
-(push (merge-pathnames "src/" *default-pathname-defaults*) asdf:*central-registry*)


### PR DESCRIPTION
Instead of playing with asdf:*central-registry* (a deprecated but
still supported method) to find our system. Putting it into the
quicklisp/local-projects directory makes sure we can find it.