### PR TITLE
Add case for representing defun with body of single atom.

### DIFF
--- a/src/representer/represent.lisp
+++ b/src/representer/represent.lisp
@@ -4,6 +4,13 @@
 
 (defmethod represent (symbol form)
   (declare (ignore symbol))
+  (or (and (symbolp form) (placeholder:rassoc form)) form))
+
+(defmethod repressent ((symbol list) form)
+  (represent (car symbol) form))
+
+(defmethod represent (symbol (form list))
+  (declare (ignore symbol))
   (mapcar
    #'(lambda (x) (if (atom x)
                 (or (and (symbolp x) (placeholder:rassoc x)) x)
@@ -30,11 +37,11 @@
   (destructuring-bind (symbol name args &body body) form
     `(,symbol ,(placeholder:add name) ,(represent :arglist args)
               ,@(multiple-value-bind (remaining declarations documentation)
-                   (alexandria:parse-body body :documentation t)
+                    (alexandria:parse-body body :documentation t)
                   (list (list :docstring (if documentation t nil))
                         (list :declare (mapcar #'(lambda (d) (represent 'declare d))
                                                declarations))
-                        (mapcar #'(lambda (f) (represent (car f) f)) remaining))))))
+                        (mapcar #'(lambda (f) (represent f f)) remaining))))))
 
 (defmethod represent ((symbol (eql :arglist)) form)
   (declare (ignore symbol))

--- a/test/represent.lisp
+++ b/test/represent.lisp
@@ -50,6 +50,11 @@
     (is (equal '((":DEFUN-0" . "FOO"))
                (placeholder:->alist)))))
 
+(test defun-body-is-atom
+  (with-fixture with-placeholders-initialized ("defun")
+    (is (equalp '(:a-single-atom)
+                (sixth (representer:represent 'defun '(defun foo () :a-single-atom)))))))
+
 (test defun-one-of-every-arg
   (with-fixture with-placeholders-initialized ("defun")
     (is (equalp '(defun :defun-0


### PR DESCRIPTION
Representer could not handle case such as found in basics exericse (`socks-and-sexprs`) which has defuns whose bodies are a single atom.

In reviewing the state of the code I see that there will be further problems. I will create an meta-issue to review the functioning of the representer against current v3 exercises. It could very well be that other exercises will also have problems (for example I see that the representer will not handle `let` very well).

Doing this will address the root cause of this failure: the lack of testing against anything but `two-fer`.