### PR TITLE
Representer does not handle dotted lists.

### DIFF
--- a/src/representer/represent.lisp
+++ b/src/representer/represent.lisp
@@ -12,11 +12,10 @@
 
 (defmethod represent (symbol (form list))
   (declare (ignore symbol))
-  (mapcar
-   #'(lambda (x) (if (atom x)
-                (represent nil x)
-                (represent (car x) x)))
-   form))
+  (let ((head (car form))
+        (tail (cdr form)))
+    (append (list (representer:represent (if (listp head) (car head) head) head))
+            (representer:represent (if (listp tail) (car tail) tail) tail))))
 
 (defmethod represent ((symbol (eql 'defpackage)) form)
   (let ((package-name (second form))

--- a/src/representer/represent.lisp
+++ b/src/representer/represent.lisp
@@ -4,16 +4,17 @@
 
 (defmethod represent (symbol form)
   (declare (ignore symbol))
-  (or (and (symbolp form) (placeholder:rassoc form)) form))
+  form)
 
-(defmethod repressent ((symbol list) form)
-  (represent (car symbol) form))
+(defmethod represent (symbol (form symbol))
+  (declare (ignore symbol))
+  (or (placeholder:rassoc form) form))
 
 (defmethod represent (symbol (form list))
   (declare (ignore symbol))
   (mapcar
    #'(lambda (x) (if (atom x)
-                (or (and (symbolp x) (placeholder:rassoc x)) x)
+                (represent nil x)
                 (represent (car x) x)))
    form))
 

--- a/test/represent.lisp
+++ b/test/represent.lisp
@@ -143,3 +143,9 @@
     (is (equalp '((list :DEFUN-1 :DEFUN-2))
                 (sixth (representer:represent
                         'defun '(defun foo (a b) (list a b))))))))
+
+(test dotted-pair
+  ;; quote here used as example symbol...
+  (with-fixture with-placeholders-initialized ("dotted-pair")
+    (is (equalp '(QUOTE (1 2 . 3))
+                (representer:represent 'quote '(quote (1 2 . 3)))))))


### PR DESCRIPTION
This cause a problem with the following v2 exercises.

- meetup
- raindrops
- rna-transcription
- scrabble-score
