### PR TITLE
Handling circular lists.

### DIFF
--- a/src/representer/represent.lisp
+++ b/src/representer/represent.lisp
@@ -1,5 +1,12 @@
 (in-package #:representer)
 
+(defun list-type (list)
+  (multiple-value-bind (length error)
+      (ignore-errors (list-length list))
+    (cond (error :dotted)
+          (length :proper)
+          (t :circular))))
+
 (defgeneric represent (symbol form))
 
 (defmethod represent (symbol form)
@@ -12,10 +19,12 @@
 
 (defmethod represent (symbol (form list))
   (declare (ignore symbol))
-  (let ((head (car form))
-        (tail (cdr form)))
-    (append (list (representer:represent (if (listp head) (car head) head) head))
-            (representer:represent (if (listp tail) (car tail) tail) tail))))
+  (if (eq :circular (list-type form))
+      form
+      (let ((head (car form))
+            (tail (cdr form)))
+        (append (list (representer:represent (if (listp head) (car head) head) head))
+                (representer:represent (if (listp tail) (car tail) tail) tail)))))
 
 (defmethod represent ((symbol (eql 'defpackage)) form)
   (let ((package-name (second form))

--- a/test/represent.lisp
+++ b/test/represent.lisp
@@ -149,3 +149,10 @@
   (with-fixture with-placeholders-initialized ("dotted-pair")
     (is (equalp '(QUOTE (1 2 . 3))
                 (representer:represent 'quote '(quote (1 2 . 3)))))))
+
+(test circular-list
+  (with-fixture with-placeholders-initialized ("circular")
+    (let ((repr (with-output-to-string (str)
+                  (write (representer:represent nil '#0=(1 2 . #0#))
+                         :stream str :circle t))))
+      (is (string= "#1=(1 2 . #1#)" repr)))))


### PR DESCRIPTION
When a circular list is detected just return the form without any
further work. This will not work in *all* cases but will at least
handle simple cases like the `prime-factors` v2 exercise's example
solution which uses a some data in the form of a circular list.

Fixes #24