### PR TITLE
Update to use clfoundation sbcl image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,28 @@
-## Build the builder image
-FROM daewok/sbcl:alpine AS build
-RUN apk update && apk upgrade
+FROM clfoundation/sbcl:2.1.5-alpine3.13 AS build
+RUN apk --no-cache add curl
 
 # Set working directory
 WORKDIR /opt/representer
-env HOME /opt/representer
+ENV HOME=/opt/representer
 
 # Pull down the latest Quicklisp
-ADD https://beta.quicklisp.org/quicklisp.lisp quicklisp/
+RUN mkdir build && curl https://beta.quicklisp.org/quicklisp.lisp -o build/quicklisp.lisp
 
-# install quicklisp
+# Install quicklisp
 COPY build/install-quicklisp.lisp build/
 RUN sbcl --script build/install-quicklisp.lisp
 
-# build the application
+# Build the application
 COPY build/build.lisp build/
 COPY src quicklisp/local-projects/representer
 RUN sbcl --script ./build/build.lisp
 
-## Build the runtime image
-FROM alpine
+# Build the runtime image
+FROM alpine:3.13
 WORKDIR /opt/representer
 
 # Copy over the representer code
-COPY --from=build /opt/representer/representer bin/
+COPY --from=build /opt/representer/bin/ bin/
 COPY bin/run.sh bin/
 
 # Set representer script as the ENTRYPOINT

--- a/build/build.lisp
+++ b/build/build.lisp
@@ -1,8 +1,10 @@
-(load "quicklisp/setup")
+(load "quicklisp/setup.lisp")
 (ql:quickload "representer")
 
-(sb-ext:save-lisp-and-die "representer"
-                          :toplevel #'(lambda ()
-                                        (apply #'representer/main:main
-                                               (uiop:command-line-arguments)))
-                          :executable t)
+(let ((bin-dir (make-pathname :directory '(:relative "bin"))))
+  (ensure-directories-exist bin-dir)
+  (sb-ext:save-lisp-and-die (merge-pathnames "representer" bin-dir)
+                            :toplevel #'(lambda ()
+                                          (apply #'representer/main:main
+                                                 (uiop:command-line-arguments)))
+                            :executable t))

--- a/build/install-quicklisp.lisp
+++ b/build/install-quicklisp.lisp
@@ -1,2 +1,2 @@
-(load "quicklisp/quicklisp.lisp")
+(load "build/quicklisp.lisp")
 (quicklisp-quickstart:install)


### PR DESCRIPTION
This change also includes a switch from ADD to RUN curl to get
quicklisp. ADD was giving a 'invalid not-modifed Etag' error which
kept the image from building.

Fixes #29