### PR TITLE
Fix writing of a circular representation.

### DIFF
--- a/src/representer/io.lisp
+++ b/src/representer/io.lisp
@@ -5,7 +5,7 @@
     (uiop:with-safe-io-syntax (:package package-name)
       (uiop:slurp-stream-forms stream))))
 
-(defun write-repr (repr stream) (write repr :stream stream))
+(defun write-repr (repr stream) (write repr :stream stream :circle t))
 
 (defun write-mapping (mapping stream)
   (if (not mapping)

--- a/test/io.lisp
+++ b/test/io.lisp
@@ -23,6 +23,10 @@
   (signals reader-error
     (io:slurp-solution (make-string-input-stream "#<foo>"))))
 
-(test slur-solution-sharpsign-dot
+(test slurp-solution-sharpsign-dot
   (signals reader-error
     (io:slurp-solution (make-string-input-stream "#.(+ 1 1)"))))
+
+(test write-circular
+  (is (string= "#1=(1 2 . #1#)"
+               (with-output-to-string (stream) (io:write-repr '#0=(1 2 . #0#) stream)))))


### PR DESCRIPTION
Previously we fixed the processing of a circular list to make a
representation - but that did not fix the actual creation of the
representation file. That was still going into an infinite loop trying
to write the infinite data structure.

Fixes #37